### PR TITLE
Allow trends to be recorded as histograms instead of summaries via options argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ k6 run -o 'prometheus=param1=value1&param2=value2' script.js
 | `subsystem` | [Prometheus subsystem](https://prometheus.io/docs/practices/naming/) for exported metrics     | `""` (empty)   |
 | `host`      | Hostname or IP address for HTTP endpoint (empty = listen on all interfaces)                   | `""` (all)     |
 | `port`      | TCP port for HTTP endpoint                                                                    | `5656`         |
+| `usehistogramfortime`      | Swaps the Prometheus metric type for time metrics to using Histograms instead of a summary.                                                                    | `"no"`(uses summary type)          |
 
 > [!TIP]
 > It's recommended to use `k6` as either `namespace` or `subsystem` to prefix metrics with `k6_`.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The extension exports k6 metrics in Prometheus text format. Metric types are map
 | Counter        | Counter         | Cumulative metric that only increases          |
 | Gauge          | Gauge           | Metric that can go up or down                  |
 | Rate           | Histogram       | Ratio of non-zero values (exported as 0 or 1)  |
-| Trend          | Summary         | Statistical aggregations with quantiles        |
+| Trend          | Summary (or Histogram)         | Statistical aggregations with quantiles        |
 
 ### Metric Labels
 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ k6 run -o 'prometheus=param1=value1&param2=value2' script.js
 > [!TIP]
 > Use quotes around the `--out` parameter to escape `&` characters from the shell.
 
-| Parameter   | Description                                                                                   | Default        |
-|-------------|-----------------------------------------------------------------------------------------------|----------------|
-| `namespace` | [Prometheus namespace](https://prometheus.io/docs/practices/naming/) for exported metrics     | `""` (empty)   |
-| `subsystem` | [Prometheus subsystem](https://prometheus.io/docs/practices/naming/) for exported metrics     | `""` (empty)   |
-| `host`      | Hostname or IP address for HTTP endpoint (empty = listen on all interfaces)                   | `""` (all)     |
-| `port`      | TCP port for HTTP endpoint                                                                    | `5656`         |
-| `usehistogramfortime`      | Swaps the Prometheus metric type for time metrics to using Histograms instead of a summary.                                                                    | `"no"`(uses summary type)          |
+| Parameter              | Description                                                                                                                                                                                               | Default               |
+|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
+| `namespace`            | [Prometheus namespace](https://prometheus.io/docs/practices/naming/) for exported metrics                                                                                                                | `""` (empty)         |
+| `subsystem`            | [Prometheus subsystem](https://prometheus.io/docs/practices/naming/) for exported metrics                                                                                                                | `""` (empty)         |
+| `host`                 | Hostname or IP address for HTTP endpoint (empty = listen on all interfaces)                                                                                                                              | `""` (all)           |
+| `port`                 | TCP port for HTTP endpoint                                                                                                                                                                               | `5656`               |
+| `usehistogramfortime`  | If set to `'true'` or `'yes'`, sets the metric type for trends to a [histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) instead of a [summary](https://prometheus.io/docs/concepts/metric_types/#summary) | `"no"` (uses summary) |
 
 > [!TIP]
 > It's recommended to use `k6` as either `namespace` or `subsystem` to prefix metrics with `k6_`.
@@ -174,16 +174,17 @@ export default function () {
 
 The extension exports k6 metrics in Prometheus text format. Metric types are mapped as follows:
 
-| k6 Metric Type | Prometheus Type | Description                                    |
-|----------------|-----------------|------------------------------------------------|
-| Counter        | Counter         | Cumulative metric that only increases          |
-| Gauge          | Gauge           | Metric that can go up or down                  |
-| Rate           | Histogram       | Ratio of non-zero values (exported as 0 or 1)  |
-| Trend          | Summary (or Histogram)         | Statistical aggregations with quantiles        |
+| k6 Metric Type | Prometheus Type         | Description                                     |
+|----------------|-------------------------|------------------------------------------------|
+| Counter        | Counter                 | Cumulative metric that only increases         |
+| Gauge          | Gauge                   | Metric that can go up or down                 |
+| Rate           | Histogram               | Ratio of non-zero values (exported as 0 or 1) |
+| Trend          | Summary (or Histogram)  | Statistical aggregations with quantiles       |
 
 ### Metric Labels
 
 All k6 metric tags are preserved as Prometheus labels:
+
 - `scenario` - Test scenario name
 - `group` - Test group name
 - `method` - HTTP method (for HTTP metrics)

--- a/prometheus.go
+++ b/prometheus.go
@@ -24,10 +24,11 @@ func init() {
 }
 
 type options struct {
-	Port      int
-	Host      string
-	Subsystem string
-	Namespace string
+	Port                int
+	Host                string
+	Subsystem           string
+	Namespace           string
+	UseHistogramForTime string
 }
 
 // Output is the Prometheus output implementation.
@@ -60,6 +61,10 @@ func (o *Output) Description() string {
 	return fmt.Sprintf("prometheus (%s)", o.addr)
 }
 
+func isOptTrue(s string) bool {
+	return s == "true" || s == "yes"
+}
+
 // Start implements output.Output.
 func (o *Output) Start() error {
 	opts, err := getopts(o.arg)
@@ -70,6 +75,7 @@ func (o *Output) Start() error {
 	o.Namespace = opts.Namespace
 	o.Subsystem = opts.Subsystem
 	o.addr = fmt.Sprintf("%s:%d", opts.Host, opts.Port)
+	o.UseHistogramForTime = isOptTrue(opts.UseHistogramForTime)
 
 	listener, err := new(net.ListenConfig).Listen(context.TODO(), "tcp", o.addr)
 	if err != nil {
@@ -94,10 +100,11 @@ func (o *Output) Stop() error {
 
 func getopts(query string) (*options, error) {
 	opts := &options{
-		Port:      defaultPort,
-		Host:      "",
-		Namespace: "",
-		Subsystem: "",
+		Port:                defaultPort,
+		Host:                "",
+		Namespace:           "",
+		Subsystem:           "",
+		UseHistogramForTime: "no",
 	}
 
 	if query == "" {


### PR DESCRIPTION
Closes #17 

This PR adds the ability to optionally record trend metrics as Prometheus Histograms instead of Summary types. This is controlled with a new option argument named `-o usehistogramfortime=yes` (name suggestions are welcome 😅)

This can be tested by passing the argument into the K6 binary when calling it after build:

Command: 

```
./k6 run -o 'prometheus=usehistogramfortime=yes' script.js
```

Which then the metrics endpoint will output this example in the trend related metrics

```
# TYPE http_req_duration histogram
...
http_req_duration_bucket{expected_response="true",group="",method="GET",name="http://test.k6.io",proto="HTTP/1.1",scenario="default",status="301",tls_version="",url="http://test.k6.io",le="2.5"} 0
http_req_duration_bucket{expected_response="true",group="",method="GET",name="http://test.k6.io",proto="HTTP/1.1",scenario="default",status="301",tls_version="",url="http://test.k6.io",le="5"} 0
...
http_req_duration_bucket{expected_response="true",group="",method="GET",name="http://test.k6.io",proto="HTTP/1.1",scenario="default",status="301",tls_version="",url="http://test.k6.io",le="+Inf"} 2

```

If you don't pass `usehistogramfortime=yes` then the default summary type is still used.

Command: 

```
./k6 run -o prometheus script.js
```

Output:

```
# TYPE http_req_duration summary
http_req_duration{expected_response="true",group="",method="GET",name="http://test.k6.io",proto="HTTP/1.1",scenario="default",status="301",tls_version="",url="http://test.k6.io",quantile="0.5"} 31.079
http_req_duration{expected_response="true",group="",method="GET",name="http://test.k6.io",proto="HTTP/1.1",scenario="default",status="301",tls_version="",url="http://test.k6.io",quantile="0.9"} 32.001
http_req_duration{expected_response="true",group="",method="GET",name="http://test.k6.io",proto="HTTP/1.1",scenario="default",status="301",tls_version="",url="http://test.k6.io",quantile="0.95"} 32.001
http_req_duration{expected_response="true",group="",method="GET",name="http://test.k6.io",proto="HTTP/1.1",scenario="default",status="301",tls_version="",url="http://test.k6.io",quantile="1"} 32.001
```

I've updated the README where I thought would be necessary but if there's any other places that should be updated please let me know. Thanks!